### PR TITLE
Correct example function signature

### DIFF
--- a/_posts/2013-07-29-quick-haskell-syntax.md
+++ b/_posts/2013-07-29-quick-haskell-syntax.md
@@ -105,7 +105,7 @@ The function takes in two variables, `x` and `y`, and just returns `x` untouched
 concatenate3 :: String -> String -> String -> String
 concatenate3 x y z = x ++ y ++ z
 
-allEqual :: (Eq a) => a -> a -> a
+allEqual :: (Eq a) => a -> a -> a -> Bool
 allEqual x y z = x == y && y == z
 {% endhighlight %}
 


### PR DESCRIPTION
The `allEqual` function's signature is incorrect. Since this is the top Google hit for "Haskell Syntax" I thought it worth raising a PR to fix.

Thanks for creating this resource.